### PR TITLE
Update mikro-orm-core.module.ts

### DIFF
--- a/src/mikro-orm-core.module.ts
+++ b/src/mikro-orm-core.module.ts
@@ -60,7 +60,7 @@ export class MikroOrmCoreModule implements OnApplicationShutdown {
 
     consumer
       .apply(MikroOrmMiddleware) // register request context automatically
-      .forRoutes({ path: '*', method: RequestMethod.ALL });
+      .forRoutes({ path: '(.*)', method: RequestMethod.ALL });
   }
 
 }


### PR DESCRIPTION
`path-to-regexp` [deprecated](https://github.com/pillarjs/path-to-regexp/blob/master/Readme.md#compatibility-with-express--4x) the usage of `*` for a wildcard route:

> No wildcard asterisk (\*) - use parameters instead ((.\*) or :splat*)

Closes: https://github.com/mikro-orm/nestjs/issues/3